### PR TITLE
Fix bug in AdviceFragmentTest

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -107,6 +107,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1760424551">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1746294260">
           <value>
             <AndroidTestResultsTableState>

--- a/app/src/main/java/com/github/sdp_begreen/begreen/fragments/AdviceFragment.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/fragments/AdviceFragment.kt
@@ -13,10 +13,11 @@ import kotlinx.coroutines.launch
 
 /**
  * A simple [Fragment] subclass.
- * Use the [AdviceFragment.newInstance] factory method to
  * create an instance of this fragment.
+ * @param testCallback A callback received from tests, it expects the set retrieved
+ *  from the database as parameter. It is null by default, should only be non null from tests.
  */
-class AdviceFragment : Fragment() {
+class AdviceFragment(private val testCallback: ((Set<String>) -> Unit)? = null) : Fragment() {
 
     // The purpose of this method is to inflate the fragment layout, initialize some views,
     // and display a random piece of advice on the screen.
@@ -32,6 +33,7 @@ class AdviceFragment : Fragment() {
             val advicesSet: Set<String> = FirebaseDB.getAdvices()
             if (advicesSet.isNotEmpty()) {
                 adviceFragmentTextView.text = advicesSet.random()
+                testCallback?.invoke(advicesSet)
             }
         }
 


### PR DESCRIPTION
I fixed the bug in `textViewDisplaysStringFromListOfAdvices` by passing a callback to the `AdviceFragment`  constructor to await for the advice fetched from the database.

I set a default value to the callback, to be able to only pass it from tests, and be able to continue using the `AdviceFragment` normally if we are not testing it.