### PR TITLE
Refactor main activity + view model

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -497,6 +497,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-498620615">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-489048379">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -159,6 +159,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1719088977">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1710205979">
           <value>
             <AndroidTestResultsTableState>
@@ -277,6 +290,19 @@
           </value>
         </entry>
         <entry key="-1331052134">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1249698421">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -890,6 +916,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="731078894">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="811358946">
           <value>
             <AndroidTestResultsTableState>
@@ -971,6 +1010,19 @@
           </value>
         </entry>
         <entry key="944144416">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="985254292">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -250,6 +250,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1331052134">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1240020416">
           <value>
             <AndroidTestResultsTableState>
@@ -575,6 +588,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-4336232">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="19495804">
           <value>
             <AndroidTestResultsTableState>
@@ -615,6 +641,19 @@
           </value>
         </entry>
         <entry key="159211119">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="260859034">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -799,6 +838,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="823282178">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="829214759">
           <value>
             <AndroidTestResultsTableState>
@@ -841,6 +893,19 @@
           </value>
         </entry>
         <entry key="931318882">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="944144416">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -918,6 +983,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1439618046">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1501204612">
           <value>
             <AndroidTestResultsTableState>
@@ -932,6 +1010,19 @@
           </value>
         </entry>
         <entry key="1557817835">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1568459697">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -984,6 +1075,19 @@
           </value>
         </entry>
         <entry key="1638461911">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1641413916">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -1049,6 +1153,19 @@
           </value>
         </entry>
         <entry key="1939421115">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1947138792">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -367,6 +367,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-968011171">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-930992459">
           <value>
             <AndroidTestResultsTableState>
@@ -1127,6 +1140,19 @@
           </value>
         </entry>
         <entry key="1399653569">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1424750908">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -146,6 +146,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1738050312">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1710205979">
           <value>
             <AndroidTestResultsTableState>
@@ -173,6 +186,19 @@
           </value>
         </entry>
         <entry key="-1588069229">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1538821114">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -393,6 +419,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-694567924">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-642592281">
           <value>
             <AndroidTestResultsTableState>
@@ -407,6 +446,19 @@
           </value>
         </entry>
         <entry key="-534433077">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-489048379">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -498,6 +550,19 @@
           </value>
         </entry>
         <entry key="-308180183">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-267012531">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -918,6 +983,45 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1042493841">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1058516057">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1122038669">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1154500684">
           <value>
             <AndroidTestResultsTableState>
@@ -1067,6 +1171,7 @@
               <option name="preferredColumnWidths">
                 <map>
                   <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
                   <entry key="Pixel_3a_API_33_x86_64" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
@@ -1166,6 +1271,19 @@
           </value>
         </entry>
         <entry key="1947138792">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="2088818707">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     implementation "androidx.fragment:fragment-ktx:1.5.6"
     debugImplementation("androidx.fragment:fragment-testing:1.5.6")
-
+    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     // Real time DB + storage + google authentificator (check the following link to add any other dependency:
     // https://firebase.google.com/docs/android/setup#available-libraries
     implementation platform('com.google.firebase:firebase-bom:31.2.3')
@@ -93,6 +93,10 @@ dependencies {
     // insert-koin
     implementation 'io.insert-koin:koin-core:3.4.0'
     implementation 'io.insert-koin:koin-android:3.4.0'
+    // Koin Test features
+    androidTestImplementation "io.insert-koin:koin-test:3.4.0"
+    // Koin for JUnit 4
+    androidTestImplementation "io.insert-koin:koin-test-junit4:3.4.0"
 
     // mockito
     testImplementation "org.mockito:mockito-core:5.2.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.test:core-ktx:1.5.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
@@ -71,11 +71,11 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     implementation "androidx.fragment:fragment-ktx:1.5.6"
-    debugImplementation("androidx.fragment:fragment-testing:1.5.6")
+    debugImplementation "androidx.fragment:fragment-testing:1.5.6"
     androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     // Real time DB + storage + google authentificator (check the following link to add any other dependency:
     // https://firebase.google.com/docs/android/setup#available-libraries
-    implementation platform('com.google.firebase:firebase-bom:31.2.3')
+    implementation platform('com.google.firebase:firebase-bom:31.5.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-database-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
@@ -87,7 +87,7 @@ dependencies {
 
     // Google dependency. See link :
     // https://developers.google.com/identity/sign-in/android/start-integrating
-    implementation 'com.google.android.gms:play-services-auth:20.4.1'
+    implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
     // insert-koin

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
@@ -1,5 +1,6 @@
 package com.github.sdp_begreen.begreen.activities
 
+import android.Manifest
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
@@ -17,6 +18,7 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import androidx.test.rule.GrantPermissionRule
 import com.github.sdp_begreen.begreen.R
 import com.github.sdp_begreen.begreen.firebase.Auth
 import com.github.sdp_begreen.begreen.firebase.DB
@@ -101,6 +103,10 @@ class MainActivityTest {
             single { auth }
         })
     )
+
+    // Need permission for camera when testing launching profile fragment
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
 
     @Test
     fun bottomNavigationBarVisible() {

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
@@ -1,7 +1,10 @@
 package com.github.sdp_begreen.begreen.activities
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
+import android.widget.ImageView
 import androidx.core.view.GravityCompat
-import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -15,39 +18,89 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.github.sdp_begreen.begreen.R
+import com.github.sdp_begreen.begreen.firebase.Auth
+import com.github.sdp_begreen.begreen.firebase.DB
+import com.github.sdp_begreen.begreen.matchers.EqualsToBitmap.Companion.equalsBitmap
+import com.github.sdp_begreen.begreen.models.PhotoMetadata
+import com.github.sdp_begreen.begreen.models.User
 import com.github.sdp_begreen.begreen.rules.KoinTestRule
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.storage.ktx.storage
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.tasks.await
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.*
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class MainActivityTest {
+
+    /**
+     * Initialize some constant to use in tests
+     */
+    companion object {
+        private val userPhotoMetadata = PhotoMetadata("user1_profile_picture")
+        private const val userId1 = "1234"
+        private const val userId2 = "1235"
+        private const val userId3 = "1236"
+        private const val userId4 = "1237"
+        private val user1 = User(
+            userId1,
+            12,
+            "User 1",
+            5,
+            null, "user 1 description", "123456789",
+            "user1@email.com", profilePictureMetadata = userPhotoMetadata)
+        private val user2 = User(
+            userId2,
+            12,
+            "User 2",
+            description = "user 2 description")
+        private val user3 = User(userId3, 10)
+        private val fakePicture1 = Bitmap.createBitmap(120, 120, Bitmap.Config.ARGB_8888)
+        private val db: DB = Mockito.mock(DB::class.java)
+        private val auth: Auth = Mockito.mock(Auth::class.java)
+        // initially do as if no user were signed in
+        private val authUserFlow = MutableStateFlow<String?>(null)
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            // The implementation need to be provided before the rule is executed,
+            // that's why we do it in the beforeClass method
+            runTest {
+                // setup basic get user and getProfilePicture use in multiple tests
+                `when`(db.getUser(userId1)).thenReturn(user1)
+                `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                    .thenReturn(fakePicture1)
+                // add a small delay, just to be sure that it is triggered after initialization
+                // and arrive second, after the initial null value
+                // use a mutable state flow, so that we can easily simulate different authenticated
+                // user between tests, by simply pushing a new userId
+                `when`(auth.getConnectedUserIds())
+                    .thenReturn(authUserFlow.onEach { delay(10) })
+            }
+        }
+    }
+
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
     @get:Rule
-    val rule = KoinTestRule()
-
-    companion object {
-        @BeforeClass
-        @JvmStatic fun setup() {
-            try {
-                Firebase.database.useEmulator("10.0.2.2", 9000)
-                Firebase.storage.useEmulator("10.0.2.2", 9199)
-                Firebase.auth.useEmulator("10.0.2.2", 9099)
-            } catch (_:java.lang.IllegalStateException){}
-        }
-
-    }
+    val koinTestRule = KoinTestRule(
+        modules = listOf(module {
+            single { db }
+            single { auth }
+        })
+    )
 
     @Test
     fun bottomNavigationBarVisible() {
@@ -96,14 +149,18 @@ class MainActivityTest {
 
     @Test
     fun pressAdviceMenuDisplayAdviceFragment() {
-        onView(withId(R.id.bottomMenuAdvice))
-            .check(matches(isDisplayed()))
-            .perform(click())
+        runTest {
+            val advices = setOf("Advice1", "Advice2", "Advice3")
+            `when`(db.getAdvices()).thenReturn(advices)
+            onView(withId(R.id.bottomMenuAdvice))
+                .check(matches(isDisplayed()))
+                .perform(click())
 
-        onView(withId(R.id.adviceFragment)).check(matches(isDisplayed()))
+            onView(withId(R.id.adviceFragment)).check(matches(isDisplayed()))
 
-        onView(withId(R.id.bottomMenuCamera))
-            .perform(click())
+            onView(withId(R.id.bottomMenuCamera))
+                .perform(click())
+        }
     }
 
     @Test
@@ -128,31 +185,24 @@ class MainActivityTest {
             .perform(click())
     }
 
-    //TODO commented for now, MUST FIND WHY int ONLY FAIL IN CI ?
-    /*@Test
+    @Test
     fun pressDrawerMenuProfileDisplayProfileDetailsFragment() {
+        runTest {
+            // sign in user
+            authUserFlow.emit(userId1)
 
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
-
-            val a = launchActivity<MainActivity>()
-
-            onView(withId(R.id.bottomMenuUser))
-                .check(matches(isDisplayed()))
-                .perform(click())
+            // Open the navigation drawer
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
             onView(withId(R.id.mainNavDrawProfile))
-                .perform(scrollTo())
                 .check(matches(isDisplayed()))
                 .perform(click())
 
             onView(withId(R.id.fragment_profile_details))
                 .check(matches(isDisplayed()))
-
-            a.close()
         }
-    }*/
+    }
 
     @Test
     fun pressDrawerMenuFollowersDisplayFollowersFragment() {
@@ -180,7 +230,8 @@ class MainActivityTest {
 
     @Test
     fun pressDrawerMenuSettingsDisplaySettingsFragment() {
-        onView(withId(R.id.mainDrawerLayout)).perform(DrawerActions.open(GravityCompat.END))
+        onView(withId(R.id.mainDrawerLayout))
+            .perform(DrawerActions.open(GravityCompat.END))
 
         onView(withId(R.id.mainNavDrawSettings))
             .perform(scrollTo())
@@ -193,9 +244,15 @@ class MainActivityTest {
 
     @Test
     fun pressDrawerMenuLogoutDisplaySignInActivity() {
+        // mock the signOutCurrentUser
+        activityRule.scenario.onActivity {
+            `when`(auth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id)))
+                .thenReturn(Tasks.forResult(null))
+        }
         Intents.init()
         // Open the navigation drawer
-        onView(withId(R.id.mainDrawerLayout)).perform(DrawerActions.open(GravityCompat.END))
+        onView(withId(R.id.mainDrawerLayout))
+            .perform(DrawerActions.open(GravityCompat.END))
 
         // Click on the Logout button
         onView(withId(R.id.mainNavDrawLogout))
@@ -208,162 +265,133 @@ class MainActivityTest {
         Intents.release()
     }
 
-    // TODO All the following test requiring a comparison of bitmap have been disabled for now
-    // TODO Need to find a better way to compare bitmap image
-
     @Test
     fun correctInfoDisplayedForAuthenticatedUser() {
+        runTest {
+            // sign in user
+            authUserFlow.emit(userId1)
 
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
-
-            // Have to explicitly create a new activity here, otherwise the logged in user is take
-            // from the moment the activity was created, which in case of "@Rules" is before,
-            // leading to an inconsistent state.
-            val a = launchActivity<MainActivity>()
-            onView(withId(R.id.bottomMenuUser))
-                .check(matches(isDisplayed()))
-                .perform(click())
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
             onView(withId(R.id.nav_drawer_username_textview))
-                .check(matches(withText("User Test 1")))
+                .check(matches(withText(user1.displayName)))
 
             onView(withId(R.id.nav_drawer_description_textview))
-                .check(matches(withText("That's the awesome description of test user 1")))
-            a.close()
+                .check(matches(withText(user1.description)))
 
+
+            activityRule.scenario.onActivity {
+                val image = it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable
+                        as BitmapDrawable
+                assertThat(image.bitmap, equalsBitmap(fakePicture1))
+            }
         }
-
-
-
-        /*activityRule.scenario.onActivity {
-            val drawable: BitmapDrawable =
-                it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable as BitmapDrawable
-
-            val expectedBitmap = BitmapFactory.decodeResource(it.resources, R.drawable.marguerite_test_image)
-            assertThat(drawable.bitmap, equalsBitmap(expectedBitmap))
-        }*/
     }
 
     @Test
     fun defaultValueDisplayedForUnauthenticatedUser() {
-        Firebase.auth.signOut() // Ensure signed out
+        runTest {
+            // simulate no authenticated user
+            authUserFlow.emit(null)
 
-        val a = launchActivity<MainActivity>()
-        assertThat(Firebase.auth.currentUser, nullValue())
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
-        onView(withId(R.id.bottomMenuUser))
-            .check(matches(isDisplayed()))
-            .perform(click())
+            onView(withId(R.id.nav_drawer_username_textview))
+                .check(matches(withText("Username")))
 
-        onView(withId(R.id.nav_drawer_username_textview))
-            .check(matches(withText("Username")))
+            onView(withId(R.id.nav_drawer_description_textview))
+                .check(matches(withText("More Info on user")))
 
-        onView(withId(R.id.nav_drawer_description_textview))
-            .check(matches((withText("More Info on user"))))
-        a.close()
 
-        /*activityRule.scenario.onActivity {
-            val drawable: BitmapDrawable =
-                it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable as BitmapDrawable
-
-            val expectedBitmap = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
-            assertThat(drawable.bitmap, equalsBitmap(expectedBitmap))
-        }*/
-
+            activityRule.scenario.onActivity {
+                val image = it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable
+                        as BitmapDrawable
+                val expected = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
+                assertThat(image.bitmap, equalsBitmap(expected))
+            }
+        }
     }
 
     @Test
     fun defaultValueDisplayedForAuthenticatedUserNotInDB() {
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("notInDb@email.com", "123456").await()
+        runTest {
+            // simulate not in db by returning a null user
+            `when`(db.getUser(userId4)).thenReturn(null)
 
-            val a = launchActivity<MainActivity>()
-            assertThat(Firebase.auth.currentUser, notNullValue())
+            // sign in user 2
+            authUserFlow.emit(userId4)
 
-            onView(withId(R.id.bottomMenuUser))
-                .check(matches(isDisplayed()))
-                .perform(click())
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
             onView(withId(R.id.nav_drawer_username_textview))
                 .check(matches(withText("Username")))
 
             onView(withId(R.id.nav_drawer_description_textview))
                 .check(matches((withText("More Info on user"))))
-            a.close()
+
+            activityRule.scenario.onActivity {
+                val image = it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable
+                        as BitmapDrawable
+                val expected = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
+                assertThat(image.bitmap, equalsBitmap(expected))
+            }
         }
-
-
-
-        /*activityRule.scenario.onActivity {
-            val drawable: BitmapDrawable =
-                it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable as BitmapDrawable
-
-            val expectedBitmap = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
-            assertThat(drawable.bitmap, equalsBitmap(expectedBitmap))
-        }*/
     }
 
     @Test
     fun defaultProfilePicturesDisplayedAuthenticatedUserNoProfilePicturedRegistered() {
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("user2@email.com", "123456").await()
+        runTest {
+            // user 2 doesn't have any profile picture
+            `when`(db.getUser(userId2)).thenReturn(user2)
 
-            val a = launchActivity<MainActivity>()
-            assertThat(Firebase.auth.currentUser, notNullValue())
+            // sign in user 2
+            authUserFlow.emit(userId2)
 
-            onView(withId(R.id.bottomMenuUser))
-                .check(matches(isDisplayed()))
-                .perform(click())
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
             onView(withId(R.id.nav_drawer_username_textview))
-                .check(matches(withText("User Test 2")))
+                .check(matches(withText("User 2")))
 
             onView(withId(R.id.nav_drawer_description_textview))
-                .check(matches((withText("User 2 descriptions"))))
-            a.close()
+                .check(matches((withText("user 2 description"))))
+
+            activityRule.scenario.onActivity {
+                val image = it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable
+                        as BitmapDrawable
+                val expected = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
+                assertThat(image.bitmap, equalsBitmap(expected))
+            }
         }
-
-        /*activityRule.scenario.onActivity {
-            val drawable: BitmapDrawable =
-                it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable as BitmapDrawable
-
-            val expectedBitmap = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
-            assertThat(drawable.bitmap, equalsBitmap(expectedBitmap))
-        }*/
-
     }
 
     @Test
     fun defaultValueDisplayedForAuthenticatedExistingUserWithoutExistingValues() {
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("user3@email.com", "123456").await()
+        runTest {
+            // user 3 doesn't have any information
+            `when`(db.getUser(userId3)).thenReturn(user3)
 
-            val a = launchActivity<MainActivity>()
-            assertThat(Firebase.auth.currentUser, notNullValue())
+            // sign in user 3
+            authUserFlow.emit(userId3)
 
-            onView(withId(R.id.bottomMenuUser))
-                .check(matches(isDisplayed()))
-                .perform(click())
+            onView(withId(R.id.mainDrawerLayout))
+                .perform(DrawerActions.open(GravityCompat.END))
 
             onView(withId(R.id.nav_drawer_username_textview))
                 .check(matches(withText("Username")))
 
             onView(withId(R.id.nav_drawer_description_textview))
                 .check(matches((withText("More Info on user"))))
-            a.close()
+
+            activityRule.scenario.onActivity {
+                val image = it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable
+                        as BitmapDrawable
+                val expected = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
+                assertThat(image.bitmap, equalsBitmap(expected))
+            }
         }
-
-        /*activityRule.scenario.onActivity {
-            val drawable: BitmapDrawable =
-                it.findViewById<ImageView>(R.id.nav_drawer_profile_picture_imageview).drawable as BitmapDrawable
-
-            val expectedBitmap = BitmapFactory.decodeResource(it.resources, R.drawable.blank_profile_picture)
-            assertThat(drawable.bitmap, equalsBitmap(expectedBitmap))
-        }*/
     }
 }

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/activities/MainActivityTest.kt
@@ -87,7 +87,7 @@ class MainActivityTest {
                 // and arrive second, after the initial null value
                 // use a mutable state flow, so that we can easily simulate different authenticated
                 // user between tests, by simply pushing a new userId
-                `when`(auth.getConnectedUserIds())
+                `when`(auth.getFlowUserIds())
                     .thenReturn(authUserFlow.onEach { delay(10) })
             }
         }

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
@@ -1,0 +1,96 @@
+package com.github.sdp_begreen.begreen.firebase
+
+import androidx.test.core.app.launchActivity
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.github.sdp_begreen.begreen.R
+import com.github.sdp_begreen.begreen.activities.MainActivity
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.Matchers.contains
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class FirebaseAuthTest {
+
+
+    companion object {
+        private val firebaseAuth = FirebaseAuth()
+        @BeforeClass
+        @JvmStatic fun setup() {
+            try {
+                Firebase.database.useEmulator("10.0.2.2", 9000)
+                Firebase.storage.useEmulator("10.0.2.2", 9199)
+                Firebase.auth.useEmulator("10.0.2.2", 9099)
+            } catch (_:java.lang.IllegalStateException){}
+        }
+    }
+
+    @get:Rule
+    val koinTestRule = KoinTestRule()
+
+    @Test
+    fun getConnectedUserIdReturnCorrectId() {
+        runBlocking {
+            Firebase.auth.signOut()
+            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
+
+            assertThat(firebaseAuth.getConnectedUserId(), `is`(equalTo(Firebase.auth.uid)))
+        }
+    }
+
+    @Test
+    fun getConnectedUserIdReturnCorrectIdsMultipleConnection() {
+        runBlocking {
+            Firebase.auth.signOut()
+            launch {
+                assertThat(firebaseAuth.getConnectedUserIds().take(6).toList(),
+                    contains(null, "VaRgQioAuiGtfDlv5uNuosNsACCJ",
+                        null,
+                        "r32POH2SnXu9dSLTxa1GMOQgg8cp",
+                        null,
+                        "IvnU7seNMaG8qrx29ps6liiJamrw"))
+            }
+
+            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
+            Firebase.auth.signOut()
+            Firebase.auth.signInWithEmailAndPassword("user2@email.com", "123456").await()
+            Firebase.auth.signOut()
+            Firebase.auth.signInWithEmailAndPassword("user3@email.com", "123456").await()
+        }
+    }
+
+    @Test
+    fun signOutCurrentUserCorrectlySignUserOut() {
+        runBlocking {
+            Firebase.auth.signOut()
+            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
+            assertThat(Firebase.auth.uid, `is`(equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
+
+            val a = launchActivity<MainActivity>()
+
+            a.onActivity {
+                firebaseAuth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id))
+            }
+
+            assertThat(Firebase.auth.uid, nullValue())
+
+            a.close()
+        }
+    }
+
+}

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
@@ -88,7 +88,7 @@ class FirebaseAuthTest {
 
     @Test
     fun signOutCurrentUserCorrectlySignUserOut() {
-        runTest {
+        runBlocking {
             Firebase.auth.signOut()
             Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
             assertThat(Firebase.auth.uid, `is`(equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTest.kt
@@ -64,11 +64,9 @@ class FirebaseAuthTest {
     @Test
     fun getConnectedUserIdReturnCorrectIdsMultipleConnection() {
         runTest {
-            Firebase.auth.signOut()
-
-            // add some delay to be sure that we are signed out before we begin listening
-            delay(10)
+            Firebase.auth.signOut() // ensure signed out
             launch {
+                delay(10)
                 assertThat(firebaseAuth.getConnectedUserIds().take(6).toList(),
                     contains(null, "VaRgQioAuiGtfDlv5uNuosNsACCJ",
                         null,
@@ -79,7 +77,7 @@ class FirebaseAuthTest {
 
             // add some delay to be sure that the listener is in place before we start
             // emitting new values
-            delay(10)
+            delay(20)
             Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
             Firebase.auth.signOut()
             Firebase.auth.signInWithEmailAndPassword("user2@email.com", "123456").await()

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
@@ -1,13 +1,9 @@
 package com.github.sdp_begreen.begreen.firebase
 
-import androidx.test.core.app.launchActivity
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.filters.LargeTest
-import com.github.sdp_begreen.begreen.R
-import com.github.sdp_begreen.begreen.activities.MainActivity
+import androidx.test.filters.MediumTest
 import com.github.sdp_begreen.begreen.rules.CoroutineTestRule
-import com.github.sdp_begreen.begreen.rules.KoinTestRule
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
@@ -17,7 +13,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.*
@@ -27,12 +22,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
-@LargeTest
-class FirebaseAuthTest {
-
-
+@MediumTest
+class FirebaseAuthTestNoUILinked {
     companion object {
         private val firebaseAuth = FirebaseAuth()
         @BeforeClass
@@ -44,9 +38,6 @@ class FirebaseAuthTest {
             } catch (_:java.lang.IllegalStateException){}
         }
     }
-
-    @get:Rule
-    val koinTestRule = KoinTestRule()
 
     @get:Rule
     val coroutineRules = CoroutineTestRule()
@@ -85,24 +76,4 @@ class FirebaseAuthTest {
             Firebase.auth.signInWithEmailAndPassword("user3@email.com", "123456").await()
         }
     }
-
-    @Test
-    fun signOutCurrentUserCorrectlySignUserOut() {
-        runBlocking {
-            Firebase.auth.signOut()
-            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
-            assertThat(Firebase.auth.uid, `is`(equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
-
-            val a = launchActivity<MainActivity>()
-
-            a.onActivity {
-                firebaseAuth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id))
-            }
-
-            assertThat(Firebase.auth.uid, nullValue())
-
-            a.close()
-        }
-    }
-
 }

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
@@ -10,6 +10,7 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -61,20 +62,20 @@ class FirebaseAuthTestNoUILinked {
     @Test
     fun getConnectedUserIdReturnCorrectIdsMultipleConnection() {
         runTest {
-            Firebase.auth.signOut() // ensure signed out
             launch {
-                delay(10)
-                assertThat(firebaseAuth.getConnectedUserIds().take(6).toList(),
+                // drop first value, will contain previously connected user if any
+                // only focus on newly emitted values
+                assertThat(firebaseAuth.getConnectedUserIds().drop(1).take(6).toList(),
                     contains(null, "VaRgQioAuiGtfDlv5uNuosNsACCJ",
                         null,
                         "r32POH2SnXu9dSLTxa1GMOQgg8cp",
                         null,
                         "IvnU7seNMaG8qrx29ps6liiJamrw"))
             }
-
             // add some delay to be sure that the listener is in place before we start
             // emitting new values
             delay(20)
+            Firebase.auth.signOut()
             Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
             Firebase.auth.signOut()
             Firebase.auth.signInWithEmailAndPassword("user2@email.com", "123456").await()

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
@@ -65,7 +65,7 @@ class FirebaseAuthTestNoUILinked {
             launch {
                 // drop first value, will contain previously connected user if any
                 // only focus on newly emitted values
-                assertThat(firebaseAuth.getConnectedUserIds().drop(1).take(6).toList(),
+                assertThat(firebaseAuth.getFlowUserIds().drop(1).take(6).toList(),
                     contains(null, "VaRgQioAuiGtfDlv5uNuosNsACCJ",
                         null,
                         "r32POH2SnXu9dSLTxa1GMOQgg8cp",

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestNoUILinked.kt
@@ -22,7 +22,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
+/**
+ * Testing [FirebaseAuth] needed to be split in half in order to be tested, due to problem
+ * with coroutine test environment and UI modification
+ *
+ * So this test class is responsible to test getting the user id which doesn't require
+ * to start any activities
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @MediumTest

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
@@ -50,15 +50,15 @@ class FirebaseAuthTestUILinked {
             Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
             assertThat(Firebase.auth.uid, `is`(equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
 
-            val a = launchActivity<MainActivity>()
+            val activityScenario = launchActivity<MainActivity>()
 
-            a.onActivity {
+            activityScenario.onActivity {
                 firebaseAuth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id))
             }
 
             assertThat(Firebase.auth.uid, nullValue())
 
-            a.close()
+            activityScenario.close()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
@@ -1,7 +1,6 @@
 package com.github.sdp_begreen.begreen.firebase
 
 import androidx.test.core.app.launchActivity
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.github.sdp_begreen.begreen.R
@@ -13,13 +12,19 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
-import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
+/**
+ * Testing [FirebaseAuth] needed to be split in half in order to be tested, due to problem
+ * with coroutine test environment and UI modification
+ *
+ * So this test class is responsible to test the sign out method, which is linked to UI
+ */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class FirebaseAuthTestUILinked {
@@ -43,7 +48,7 @@ class FirebaseAuthTestUILinked {
         runBlocking {
             Firebase.auth.signOut()
             Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
-            ViewMatchers.assertThat(Firebase.auth.uid, CoreMatchers.`is`(CoreMatchers.equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
+            assertThat(Firebase.auth.uid, `is`(equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
 
             val a = launchActivity<MainActivity>()
 
@@ -51,7 +56,7 @@ class FirebaseAuthTestUILinked {
                 firebaseAuth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id))
             }
 
-            ViewMatchers.assertThat(Firebase.auth.uid, CoreMatchers.nullValue())
+            assertThat(Firebase.auth.uid, nullValue())
 
             a.close()
         }

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuthTestUILinked.kt
@@ -1,0 +1,59 @@
+package com.github.sdp_begreen.begreen.firebase
+
+import androidx.test.core.app.launchActivity
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.github.sdp_begreen.begreen.R
+import com.github.sdp_begreen.begreen.activities.MainActivity
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.hamcrest.CoreMatchers
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class FirebaseAuthTestUILinked {
+    companion object {
+        private val firebaseAuth = FirebaseAuth()
+        @BeforeClass
+        @JvmStatic fun setup() {
+            try {
+                Firebase.database.useEmulator("10.0.2.2", 9000)
+                Firebase.storage.useEmulator("10.0.2.2", 9199)
+                Firebase.auth.useEmulator("10.0.2.2", 9099)
+            } catch (_:java.lang.IllegalStateException){}
+        }
+    }
+
+    @get:Rule
+    val koinTestRule = KoinTestRule()
+
+    @Test
+    fun signOutCurrentUserCorrectlySignUserOut() {
+        runBlocking {
+            Firebase.auth.signOut()
+            Firebase.auth.signInWithEmailAndPassword("user1@email.ch", "123456").await()
+            ViewMatchers.assertThat(Firebase.auth.uid, CoreMatchers.`is`(CoreMatchers.equalTo("VaRgQioAuiGtfDlv5uNuosNsACCJ")))
+
+            val a = launchActivity<MainActivity>()
+
+            a.onActivity {
+                firebaseAuth.signOutCurrentUser(it, it.getString(R.string.default_web_client_id))
+            }
+
+            ViewMatchers.assertThat(Firebase.auth.uid, CoreMatchers.nullValue())
+
+            a.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/AdviceFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/AdviceFragmentTest.kt
@@ -26,7 +26,7 @@ class AdviceFragmentTest {
     private val db: DB = mock(DB::class.java)
 
     @get:Rule
-    val koinTEstRule = KoinTestRule(
+    val koinTestRule = KoinTestRule(
         modules = listOf(module {
             single {db}
         })

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/CameraFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/CameraFragmentTest.kt
@@ -14,12 +14,10 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.GrantPermissionRule
 import com.github.sdp_begreen.begreen.R
-import com.github.sdp_begreen.begreen.activities.MainActivity
 import com.github.sdp_begreen.begreen.activities.SharePostActivity
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -32,9 +30,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class CameraFragmentTest {
-
-    @get:Rule
-    val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
     @get:Rule
     val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
@@ -114,7 +114,7 @@ class ProfileDetailsFragmentTest {
         frag.onFragment {
             val connectedUserViewModel:
                     ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-            connectedUserViewModel.currentUser.value = user2
+        connectedUserViewModel.setCurrentUser(user2)
         }
 
         onView(withId(R.id.fragment_profile_details_edit_profile))
@@ -133,11 +133,12 @@ class ProfileDetailsFragmentTest {
 
         val bundle = Bundle().apply { putParcelable(ARG_USER, user) }
         val frag = launchFragmentInContainer<ProfileDetailsFragment>(bundle)
+        Firebase.auth.signOut()
 
         frag.onFragment {
             val connectedUserViewModel:
                     ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-            connectedUserViewModel.currentUser.value = user
+            connectedUserViewModel.setCurrentUser(user)
         }
 
         onView(withId(R.id.fragment_profile_details_edit_profile))
@@ -156,7 +157,7 @@ class ProfileDetailsFragmentTest {
         frag.onFragment {
             val connectedUserViewModel:
                     ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-            connectedUserViewModel.currentUser.value = user
+            connectedUserViewModel.setCurrentUser(user)
         }
 
         onView(withId(R.id.fragment_profile_details_save_profile))
@@ -182,7 +183,7 @@ class ProfileDetailsFragmentTest {
         frag.onFragment {
             val connectedUserViewModel:
                     ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-            connectedUserViewModel.currentUser.value = user
+            connectedUserViewModel.setCurrentUser(user)
         }
 
         onView(withId(R.id.fragment_profile_details_take_picture))
@@ -222,7 +223,7 @@ class ProfileDetailsFragmentTest {
             onFragment {
                 val connectedUserViewModel:
                         ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-                connectedUserViewModel.currentUser.value = user
+                connectedUserViewModel.setCurrentUser(user)
             }
 
             // initially test that the user does not contains any profile picture metadata
@@ -296,7 +297,7 @@ class ProfileDetailsFragmentTest {
             onFragment {
                 val connectedUserViewModel:
                         ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-                connectedUserViewModel.currentUser.value = user
+                connectedUserViewModel.setCurrentUser(user)
 
                 // initially check that no profile picture is associated with this user
                 assertThat(connectedUserViewModel.currentUserProfilePicture.value, `is`(nullValue()))
@@ -317,7 +318,6 @@ class ProfileDetailsFragmentTest {
             onFragment {
                 val connectedUserViewModel:
                         ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-                connectedUserViewModel.currentUser.value = user
 
                 // check that the value is now the taken picture
                 assertThat(connectedUserViewModel.currentUserProfilePicture.value, `is`(sameInstance(fakePicture)))
@@ -337,8 +337,7 @@ class ProfileDetailsFragmentTest {
         frag.onFragment {
             val connectedUserViewModel:
                     ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-            connectedUserViewModel.currentUser.value = fakeAuthUser
-            connectedUserViewModel.currentUserProfilePicture.value = null
+            connectedUserViewModel.setCurrentUser(fakeAuthUser)
         }
 
         onView(withId(R.id.fragment_profile_details_profile_name))

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
@@ -24,6 +24,7 @@ import com.github.sdp_begreen.begreen.firebase.FirebaseDB
 import com.github.sdp_begreen.begreen.models.ParcelableDate
 import com.github.sdp_begreen.begreen.models.PhotoMetadata
 import com.github.sdp_begreen.begreen.models.User
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
 import com.github.sdp_begreen.begreen.viewModels.ConnectedUserViewModel
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.ktx.database
@@ -60,8 +61,12 @@ class ProfileDetailsFragmentTest {
     private val ARG_USER = "USER"
     lateinit var fragScenario: FragmentScenario<ProfileDetailsFragment>
     private val ARG_RECENT_POSTS = "recent_posts"
+
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @get:Rule
+    val koinTestRule = KoinTestRule()
 
     @Before
     fun setup() {

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragmentTest.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.viewModels
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -92,14 +91,14 @@ class ProfileDetailsFragmentTest {
     @Test
     fun testProfileDetailsFragmentFollowButton(){
         onView(withId(R.id.fragment_profile_details_follow_button)).perform(click())
-        onView(withId(R.id.fragment_profile_details_follow_button)).check(matches(ViewMatchers.withText("Unfollow")))
+        onView(withId(R.id.fragment_profile_details_follow_button)).check(matches(withText("Unfollow")))
     }
 
     @Test
     fun testProfileDetailsFragmentFollowButton2(){
         onView(withId(R.id.fragment_profile_details_follow_button)).perform(click())
         onView(withId(R.id.fragment_profile_details_follow_button)).perform(click())
-        onView(withId(R.id.fragment_profile_details_follow_button)).check(matches(ViewMatchers.withText("Follow")))
+        onView(withId(R.id.fragment_profile_details_follow_button)).check(matches(withText("Follow")))
     }
 
     @Test
@@ -117,9 +116,9 @@ class ProfileDetailsFragmentTest {
         val frag = launchFragmentInContainer<ProfileDetailsFragment>(bundle)
 
         frag.onFragment {
-            val connectedUserViewModel:
-                    ConnectedUserViewModel by it.viewModels(ownerProducer = { it.requireActivity() })
-        connectedUserViewModel.setCurrentUser(user2)
+            val connectedUserViewModel
+                by it.viewModels<ConnectedUserViewModel>(ownerProducer = { it.requireActivity() })
+            connectedUserViewModel.setCurrentUser(user2)
         }
 
         onView(withId(R.id.fragment_profile_details_edit_profile))

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserFragmentTest.kt
@@ -13,6 +13,7 @@ import androidx.test.filters.LargeTest
 import com.github.sdp_begreen.begreen.R
 import com.github.sdp_begreen.begreen.models.User
 import com.github.sdp_begreen.begreen.activities.MainActivity
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
 import junit.framework.TestCase.*
 import org.hamcrest.CoreMatchers
 import org.junit.Before
@@ -25,6 +26,9 @@ import org.junit.runner.RunWith
 class UserFragmentTest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @get:Rule
+    val koinTestRule = KoinTestRule()
 
     private lateinit var fragment: UserFragment
     private lateinit var userList: List<User>

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserPhotoFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserPhotoFragmentTest.kt
@@ -16,6 +16,7 @@ import com.github.sdp_begreen.begreen.models.User
 import com.github.sdp_begreen.begreen.activities.MainActivity
 import com.github.sdp_begreen.begreen.models.ParcelableDate
 import com.github.sdp_begreen.begreen.models.PhotoMetadata
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
 import junit.framework.TestCase.*
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.instanceOf
@@ -31,6 +32,9 @@ import kotlin.collections.ArrayList
 class UserPhotoFragmentTest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @get:Rule
+    val koinTestRule = KoinTestRule()
 
     private lateinit var fragment: UserPhotoFragment
     private lateinit var photoList: List<PhotoMetadata>

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserPhotosViewAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserPhotosViewAdapterTest.kt
@@ -16,6 +16,7 @@ import com.github.sdp_begreen.begreen.databinding.FragmentUserPhotoBinding
 import com.github.sdp_begreen.begreen.models.ParcelableDate
 import com.github.sdp_begreen.begreen.models.PhotoMetadata
 import com.github.sdp_begreen.begreen.models.User
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
@@ -26,6 +27,9 @@ import java.util.*
 class UserPhotosViewAdapterTest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    @get:Rule
+    val koinTestRule = KoinTestRule()
+
     private val photoList = listOf(
         PhotoMetadata("1", "title", ParcelableDate(Date()), User("1", 812, "Alice", 3), "Gros vilain pas beau", "desc"),
         PhotoMetadata("2", "title2", ParcelableDate(Date()), User("2", 81, "Bob", 4), "Gros vilain tout beau", "desc2")

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserViewAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/fragments/UserViewAdapterTest.kt
@@ -16,10 +16,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import com.github.sdp_begreen.begreen.R
+import com.github.sdp_begreen.begreen.rules.KoinTestRule
 
 class UserViewAdapterTest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    @get:Rule
+    val koinTestRule = KoinTestRule()
+
     private var userViewAdapter = UserViewAdapter(listOf(User("1",  0, "Test"), User("2",  1, "Test2")), null)
     private val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     private val userList = listOf(

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/matchers/EqualsToBitmap.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/matchers/EqualsToBitmap.kt
@@ -1,71 +1,38 @@
 package com.github.sdp_begreen.begreen.matchers
 
 import android.graphics.Bitmap
-import android.util.Log
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
-import java.io.ByteArrayOutputStream
-import kotlin.properties.Delegates
 
 /**
  * Custom matcher class, to compare two bitmaps and know whether they are the same or not
- *
- * This matcher is not working yet, we need to find a way to be able to compare bitmap
- * when they have been compressed an uncompressed
  */
 class EqualsToBitmap private constructor(private val bmp: Bitmap): TypeSafeMatcher<Bitmap>() {
 
-    var counter1 by Delegates.notNull<Int>()
-    var numberElm by Delegates.notNull<Int>()
-
     override fun describeTo(description: Description?) {
-        description?.appendText(String.format("Expected item width: %s, expected item height: %s\n", bmp.width.toString(), bmp.height.toString()))
-        description?.appendText("\n Expected counter: $numberElm")
-
+        description?.appendText("width: ${bmp.width}, height: ${bmp.height}")
     }
 
     override fun matchesSafely(item: Bitmap?): Boolean {
         if (item == null) return false
 
-        val width = bmp.width.coerceAtMost(item.width)
-        val height = bmp.height.coerceAtMost(item.height)
-        val bmp2 = Bitmap.createScaledBitmap(bmp, width, height, false)
-        val item2 = Bitmap.createScaledBitmap(item, width, height, false)
-
-
-
-        val b1 = ByteArrayOutputStream()
-        val b2 = ByteArrayOutputStream()
-        bmp2.compress(Bitmap.CompressFormat.JPEG, 100, b1)
-        item2.compress(Bitmap.CompressFormat.JPEG, 100, b2)
-
-        // If any pixel is not the same, return false, image are not the same (see if must add threshold)
-        var counter = 0
-        val bA1 = b1.toByteArray()
-        val bA2 = b2.toByteArray()
-        numberElm = if (bA1.size < bA2.size) bA1.size else bA2.size
-        b1.toByteArray().zip(b2.toByteArray()).forEach {
-
-            Log.d("first and second", "${it.first} : ${it.second}")
-            if (it.first != it.second) counter++
-        }
-
-        // TODO This doesn't work I think compressing and uncompressing image are not always the same
-        // TODO Is it another way to compare Bitmap ?
-        counter1 = counter
-        Log.d("total elem and different elem", "$numberElm : $counter")
-        if (counter / numberElm.toDouble() > 0.1) return false
+        if (item.height != bmp.height || item.width != bmp.width) return false
 
         return true
     }
 
     override fun describeMismatchSafely(item: Bitmap?, mismatchDescription: Description?) {
-        mismatchDescription?.appendText(String.format("Received item width: %s, received item height: %s\n", item!!.width.toString(), item.height.toString()))
-        mismatchDescription?.appendText("\n Received counter: $counter1")
+        mismatchDescription?.appendText("width: ${item?.width}, height: ${item?.height}")
     }
 
     companion object {
+        /**
+         * Check bitmap width and height to uniquely identify bitmap
+         *
+         * It should be to the tester responsibility to ensure that no two
+         * fake test bitmap could be equal by chance
+         */
         fun equalsBitmap(bmp: Bitmap): Matcher<Bitmap> = EqualsToBitmap(bmp)
     }
 

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/rules/CoroutineTestRule.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/rules/CoroutineTestRule.kt
@@ -1,0 +1,23 @@
+package com.github.sdp_begreen.begreen.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineTestRule(val dispatcher: TestDispatcher = UnconfinedTestDispatcher()): TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
@@ -16,6 +16,8 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,24 +39,40 @@ class ConnectedUserViewModelTest: KoinTest {
      * Initialize some constant to use in every tests
      */
     companion object {
+        private val db: DB = mock(DB::class.java)
+        private val auth: Auth = mock(Auth::class.java)
         private val userPhotoMetadata = PhotoMetadata("user1_profile_picture")
+        private val userPhotoMetadata2 = PhotoMetadata("user3_profile_picture")
         private const val userId1 = "1234"
         private const val userId2 = "1235"
         private const val userId3 = "1236"
         private val user1 = User(userId1, 12, "User 1", profilePictureMetadata = userPhotoMetadata)
         private val user2 = User(userId2, 12, "User 2")
-        private val user3 = User(userId3, 12, "User 3")
+        private val user3 = User(userId3, 12, "User 3", profilePictureMetadata = userPhotoMetadata2)
         private val fakePicture1 = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
         private val fakePicture2 = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpAuth() {
+            // The implementation need to be provided before the rule is executed,
+            // that's why we do it in the beforeClass method
+            runTest {
+                // setup basic get user and getProfilePicture use in multiple tests
+                `when`(db.getUser(userId1)).thenReturn(user1)
+                `when`(db.getUser(userId2)).thenReturn(user2)
+                `when`(db.getUser(userId3)).thenReturn(user3)
+                `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                    .thenReturn(fakePicture1)
+                // add a small delay, just to be sure that it is triggered after initialization
+                // and arrive second, after the initial null value
+                `when`(auth.getConnectedUserIds())
+                    .thenReturn(flowOf(userId1).onEach { delay(10) })
+            }
+        }
     }
 
-    private val db: DB = mock(DB::class.java)
-    private val auth: Auth = mock(Auth::class.java)
-
-    private val testModule = module {
-        single { db }
-        single { auth }
-    }
+    private lateinit var vm: ConnectedUserViewModel
 
     /**
      * Needed to be able to test coroutine
@@ -70,20 +88,20 @@ class ConnectedUserViewModelTest: KoinTest {
      */
     @get:Rule
     val koinTestRule = KoinTestRule.create {
-        modules(testModule)
+        modules(module {
+            single { db }
+            single { auth }
+        })
+    }
+
+    @Before
+    fun setUpVM() {
+        vm = ConnectedUserViewModel()
     }
 
     @Test
     fun currentUserContainCorrectSignInUser() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            // add a small delay, just to be sure that it is triggered after initialization
-            // and arrive second, after the initial null value
-            `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(userId1).onEach { delay(10) })
-
-            val vm = ConnectedUserViewModel()
-
             assertThat(vm.currentUser.drop(1).first(), `is`(equalTo(user1)))
         }
     }
@@ -91,11 +109,6 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserContainsCorrectUserSetManually() {
         runTest {
-            // Still need to mock this method to avoid null pointer
-            `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(null).onEach { delay(10) })
-
-            val vm = ConnectedUserViewModel()
             vm.setCurrentUser(user1)
 
             assertThat(vm.currentUser.first(), `is`(equalTo(user1)))
@@ -105,14 +118,11 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserContainCorrectSignInUserChangingUser() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUser(userId2)).thenReturn(user2)
-            `when`(db.getUser(userId3)).thenReturn(user3)
             `when`(auth.getConnectedUserIds())
                 .thenReturn(flowOf(userId1, userId2, userId3).onEach { delay(10) })
 
+            // need new vm, as we modify the "getConnectedUserIds" value
             val vm = ConnectedUserViewModel()
-
             val users = vm.currentUser.drop(1).take(3).toList()
             assertThat(users, contains(user1, user2, user3))
         }
@@ -121,13 +131,10 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserCorrectValueAuthAndUpdateUser() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUser(userId3)).thenReturn(user3)
             `when`(auth.getConnectedUserIds())
                 .thenReturn(flowOf(userId1, userId3).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()
-
             // need to explicitly launch it for it to go into the dispatcher
             launch {
                 delay(15)
@@ -142,13 +149,6 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserProfilePictureCorrectlySetSignedInUser() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
-                .thenReturn(fakePicture1)
-            `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(userId1).onEach { delay(10) })
-
-            val vm = ConnectedUserViewModel()
             assertThat(
                 vm.currentUserProfilePicture.drop(1).first(),
                 `is`(equalTo(fakePicture1)))
@@ -156,15 +156,22 @@ class ConnectedUserViewModelTest: KoinTest {
     }
 
     @Test
-    fun currentUserProfilePictureCorrectlyResetManuallyModifyingUser() {
+    fun currentUserProfilePictureCorrectlyResetUponNewAuth() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
-                .thenReturn(fakePicture1)
             `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(userId1).onEach { delay(10) })
+                .thenReturn(flowOf(userId1, userId2).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()
+            assertThat(
+                vm.currentUserProfilePicture.drop(1).take(2).toList(),
+                contains(fakePicture1, null)
+            )
+        }
+    }
+
+    @Test
+    fun currentUserProfilePictureCorrectlyResetManuallyModifyingUser() {
+        runTest {
             launch {
                 delay(15)
                 vm.setCurrentUser(user2)
@@ -178,15 +185,25 @@ class ConnectedUserViewModelTest: KoinTest {
     }
 
     @Test
-    fun currentUserProfilePictureCorrectManuallyModified() {
+    fun currentUserProfilePictureCorrectlyUpdatedUponNewAuth() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
-                .thenReturn(fakePicture1)
+            `when`(db.getUserProfilePicture(userPhotoMetadata2, userId3))
+                .thenReturn(fakePicture2)
             `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(userId1).onEach { delay(10) })
+                .thenReturn(flowOf(userId1, userId3).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()
+            assertThat(
+                vm.currentUserProfilePicture.drop(1).take(2).toList(),
+                contains(fakePicture1, fakePicture2)
+            )
+        }
+    }
+
+
+    @Test
+    fun currentUserProfilePictureCorrectManuallyModified() {
+        runTest {
             launch {
                 delay(15)
                 vm.setCurrentUserProfilePicture(fakePicture2, userId1)
@@ -202,13 +219,6 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun setCurrentUserProfilePictureThrowsWrongUserId() {
         runTest {
-            `when`(db.getUser(userId1)).thenReturn(user1)
-            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
-                .thenReturn(fakePicture1)
-            `when`(auth.getConnectedUserIds())
-                .thenReturn(flowOf(userId1).onEach { delay(10) })
-
-            val vm = ConnectedUserViewModel()
             launch {
                 delay(15)
                 val exception = assertThrows(IllegalArgumentException::class.java) {

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
@@ -1,0 +1,222 @@
+package com.github.sdp_begreen.begreen.viewModels
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.github.sdp_begreen.begreen.firebase.Auth
+import com.github.sdp_begreen.begreen.firebase.DB
+import com.github.sdp_begreen.begreen.models.PhotoMetadata
+import com.github.sdp_begreen.begreen.models.User
+import com.github.sdp_begreen.begreen.rules.CoroutineTestRule
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.*
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.KoinTestRule
+import org.mockito.Mockito.*
+
+/**
+ * I started by putting this test in the unit test package, but I needed support from android
+ * to be able to test bitmap, as they are not implemented for simple unit test
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class ConnectedUserViewModelTest: KoinTest {
+
+    /**
+     * Initialize some constant to use in every tests
+     */
+    companion object {
+        private val userPhotoMetadata = PhotoMetadata("user1_profile_picture")
+        private const val userId1 = "1234"
+        private const val userId2 = "1235"
+        private const val userId3 = "1236"
+        private val user1 = User(userId1, 12, "User 1", profilePictureMetadata = userPhotoMetadata)
+        private val user2 = User(userId2, 12, "User 2")
+        private val user3 = User(userId3, 12, "User 3")
+        private val fakePicture1 = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        private val fakePicture2 = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    }
+
+    private val db: DB = mock(DB::class.java)
+    private val auth: Auth = mock(Auth::class.java)
+
+    private val testModule = module {
+        single { db }
+        single { auth }
+    }
+
+    /**
+     * Needed to be able to test coroutine
+     * https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/
+     */
+    @get:Rule
+    val coroutineRules = CoroutineTestRule()
+
+    /**
+     * As I only test the viewModel without actually starting any activity or fragment,
+     * I don't need to use the [com.github.sdp_begreen.begreen.rules.KoinTestRule] that launch an
+     * actual instrumented test
+     */
+    @get:Rule
+    val koinTestRule = KoinTestRule.create {
+        modules(testModule)
+    }
+
+    @Test
+    fun currentUserContainCorrectSignInUser() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            // add a small delay, just to be sure that it is triggered after initialization
+            // and arrive second, after the initial null value
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+
+            assertThat(vm.currentUser.drop(1).first(), `is`(equalTo(user1)))
+        }
+    }
+
+    @Test
+    fun currentUserContainsCorrectUserSetManually() {
+        runTest {
+            // Still need to mock this method to avoid null pointer
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(null).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+            vm.setCurrentUser(user1)
+
+            assertThat(vm.currentUser.first(), `is`(equalTo(user1)))
+        }
+    }
+
+    @Test
+    fun currentUserContainCorrectSignInUserChangingUser() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUser(userId2)).thenReturn(user2)
+            `when`(db.getUser(userId3)).thenReturn(user3)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1, userId2, userId3).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+
+            val users = vm.currentUser.drop(1).take(3).toList()
+            assertThat(users, contains(user1, user2, user3))
+        }
+    }
+
+    @Test
+    fun currentUserCorrectValueAuthAndUpdateUser() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUser(userId3)).thenReturn(user3)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1, userId3).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+
+            // need to explicitly launch it for it to go into the dispatcher
+            launch {
+                delay(15)
+                vm.setCurrentUser(user2)
+            }
+
+            val users = vm.currentUser.drop(1).take(3).toList()
+            assertThat(users, contains(user1, user2, user3))
+        }
+    }
+
+    @Test
+    fun currentUserProfilePictureCorrectlySetSignedInUser() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                .thenReturn(fakePicture1)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+            assertThat(
+                vm.currentUserProfilePicture.drop(1).first(),
+                `is`(equalTo(fakePicture1)))
+        }
+    }
+
+    @Test
+    fun currentUserProfilePictureCorrectlyResetManuallyModifyingUser() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                .thenReturn(fakePicture1)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+            launch {
+                delay(15)
+                vm.setCurrentUser(user2)
+            }
+
+            assertThat(
+                vm.currentUserProfilePicture.drop(1).take(2).toList(),
+                contains(fakePicture1, null)
+            )
+        }
+    }
+
+    @Test
+    fun currentUserProfilePictureCorrectManuallyModified() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                .thenReturn(fakePicture1)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+            launch {
+                delay(15)
+                vm.setCurrentUserProfilePicture(fakePicture2, userId1)
+            }
+
+            assertThat(
+                vm.currentUserProfilePicture.drop(1).take(2).toList(),
+                contains(fakePicture1, fakePicture2)
+            )
+        }
+    }
+
+    @Test
+    fun setCurrentUserProfilePictureThrowsWrongUserId() {
+        runTest {
+            `when`(db.getUser(userId1)).thenReturn(user1)
+            `when`(db.getUserProfilePicture(userPhotoMetadata, userId1))
+                .thenReturn(fakePicture1)
+            `when`(auth.getConnectedUserIds())
+                .thenReturn(flowOf(userId1).onEach { delay(10) })
+
+            val vm = ConnectedUserViewModel()
+            launch {
+                delay(15)
+                val exception = assertThrows(IllegalArgumentException::class.java) {
+                    vm.setCurrentUserProfilePicture(fakePicture2, "1111")
+                }
+                assertThat(exception.message, `is`(equalTo("Trying to modify profile picture of another user")))
+            }
+        }
+    }
+
+}

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
@@ -66,7 +66,7 @@ class ConnectedUserViewModelTest: KoinTest {
                     .thenReturn(fakePicture1)
                 // add a small delay, just to be sure that it is triggered after initialization
                 // and arrive second, after the initial null value
-                `when`(auth.getConnectedUserIds())
+                `when`(auth.getFlowUserIds())
                     .thenReturn(flowOf(userId1).onEach { delay(10) })
             }
         }
@@ -118,7 +118,7 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserContainCorrectSignInUserChangingUser() {
         runTest {
-            `when`(auth.getConnectedUserIds())
+            `when`(auth.getFlowUserIds())
                 .thenReturn(flowOf(userId1, userId2, userId3).onEach { delay(10) })
 
             // need new vm, as we modify the "getConnectedUserIds" value
@@ -131,7 +131,7 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserCorrectValueAuthAndUpdateUser() {
         runTest {
-            `when`(auth.getConnectedUserIds())
+            `when`(auth.getFlowUserIds())
                 .thenReturn(flowOf(userId1, userId3).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()
@@ -158,7 +158,7 @@ class ConnectedUserViewModelTest: KoinTest {
     @Test
     fun currentUserProfilePictureCorrectlyResetUponNewAuth() {
         runTest {
-            `when`(auth.getConnectedUserIds())
+            `when`(auth.getFlowUserIds())
                 .thenReturn(flowOf(userId1, userId2).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()
@@ -189,7 +189,7 @@ class ConnectedUserViewModelTest: KoinTest {
         runTest {
             `when`(db.getUserProfilePicture(userPhotoMetadata2, userId3))
                 .thenReturn(fakePicture2)
-            `when`(auth.getConnectedUserIds())
+            `when`(auth.getFlowUserIds())
                 .thenReturn(flowOf(userId1, userId3).onEach { delay(10) })
 
             val vm = ConnectedUserViewModel()

--- a/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModelTest.kt
@@ -229,4 +229,18 @@ class ConnectedUserViewModelTest: KoinTest {
         }
     }
 
+
+    @Test
+    fun setCurrentUserProfilePictureThrowsNullUserId() {
+        runTest {
+            launch {
+                delay(15)
+                val exception = assertThrows(IllegalArgumentException::class.java) {
+                    vm.setCurrentUserProfilePicture(fakePicture2, null)
+                }
+                assertThat(exception.message, `is`(equalTo("Trying to modify profile picture of another user")))
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/github/sdp_begreen/begreen/BeGreenApp.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/BeGreenApp.kt
@@ -1,7 +1,9 @@
 package com.github.sdp_begreen.begreen
 
 import android.app.Application
+import com.github.sdp_begreen.begreen.firebase.Auth
 import com.github.sdp_begreen.begreen.firebase.DB
+import com.github.sdp_begreen.begreen.firebase.FirebaseAuth
 import com.github.sdp_begreen.begreen.firebase.FirebaseDB
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -12,6 +14,7 @@ import org.koin.dsl.module
  */
 val productionDbModule = module {
     single<DB> { FirebaseDB }
+    single<Auth> { FirebaseAuth() }
 }
 
 /**

--- a/app/src/main/java/com/github/sdp_begreen/begreen/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/activities/MainActivity.kt
@@ -253,7 +253,7 @@ class MainActivity : AppCompatActivity() {
                         val intent = Intent(this, SignInActivity::class.java)
 
                         // short toast message to the user indicating that they are being logged out
-                        Toast.makeText(this, "Logging Out", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this, getString(R.string.toast_logout_info), Toast.LENGTH_SHORT).show()
 
                         // When the sign-out operation is complete, it starts SignInActivity again<
                         startActivity(intent)

--- a/app/src/main/java/com/github/sdp_begreen/begreen/firebase/Auth.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/firebase/Auth.kt
@@ -20,7 +20,7 @@ interface Auth {
      *
      * @return Returns a flow that will emit last uid upon changes
      */
-    fun getConnectedUserIds(): Flow<String?>
+    fun getFlowUserIds(): Flow<String?>
 
     /**
      * Method to sign out the currently logged in user

--- a/app/src/main/java/com/github/sdp_begreen/begreen/firebase/Auth.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/firebase/Auth.kt
@@ -1,0 +1,32 @@
+package com.github.sdp_begreen.begreen.firebase
+
+import android.app.Activity
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.flow.Flow
+
+interface Auth {
+
+    /**
+     * Method to get the uid of the currently authenticated user
+     *
+     * @return Returns the uid of the currently authenticated user
+     */
+    fun getConnectedUserId(): String?
+
+    /**
+     * Method to get the uid of the currently authenticated user as a flow, (i.e. the
+     * collector of this flow will receive the new uid upon changes in authentication
+     * status)
+     *
+     * @return Returns a flow that will emit last uid upon changes
+     */
+    fun getConnectedUserIds(): Flow<String?>
+
+    /**
+     * Method to sign out the currently logged in user
+     *
+     * @param activity The activity from which we are calling the sign out method
+     * @param webClientId The id token to identify the connected user
+     */
+    fun signOutCurrentUser(activity: Activity, webClientId: String): Task<Void>
+}

--- a/app/src/main/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuth.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuth.kt
@@ -19,7 +19,7 @@ class FirebaseAuth: Auth {
 
     override fun getConnectedUserId(): String? = Firebase.auth.uid
 
-    override fun getConnectedUserIds(): Flow<String?> = callbackFlow {
+    override fun getFlowUserIds(): Flow<String?> = callbackFlow {
             val listener = FirebaseAuth.AuthStateListener { auth -> trySend(auth.uid) }
             Firebase.auth.addAuthStateListener(listener)
 

--- a/app/src/main/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuth.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/firebase/FirebaseAuth.kt
@@ -1,0 +1,44 @@
+package com.github.sdp_begreen.begreen.firebase
+
+
+import android.app.Activity
+import android.content.res.Resources
+import com.github.sdp_begreen.begreen.R
+import com.github.sdp_begreen.begreen.social.GoogleAuth
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+class FirebaseAuth: Auth {
+
+    override fun getConnectedUserId(): String? = Firebase.auth.uid
+
+    override fun getConnectedUserIds(): Flow<String?> = callbackFlow {
+            val listener = FirebaseAuth.AuthStateListener { auth -> trySend(auth.uid) }
+            Firebase.auth.addAuthStateListener(listener)
+
+            // Unregister the listener to avoid memory leak upon flow deletion
+            awaitClose {
+                Firebase.auth.removeAuthStateListener(listener)
+            }
+        }
+
+    override fun signOutCurrentUser(activity: Activity, webClientId: String): Task<Void> {
+        Firebase.auth.signOut()
+
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(webClientId)
+            .requestEmail()
+            .build()
+
+        GoogleAuth.mGoogleSignInClient = GoogleSignIn.getClient(activity, gso)
+
+        return GoogleAuth.mGoogleSignInClient.signOut()
+    }
+}

--- a/app/src/main/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragment.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragment.kt
@@ -2,8 +2,7 @@ package com.github.sdp_begreen.begreen.fragments
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.graphics.*
-import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -18,13 +17,9 @@ import androidx.activity.result.launch
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.ProgressBar
-import android.widget.RatingBar
-import android.widget.TextView
-import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.github.sdp_begreen.begreen.R
 import com.github.sdp_begreen.begreen.firebase.FirebaseDB
 import com.github.sdp_begreen.begreen.models.Actions
@@ -44,8 +39,8 @@ import java.util.*
  */
 class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultRegistry? = null)
     : Fragment() {
-    var user: User? = null
-    var recentPosts: List<PhotoMetadata>? = null
+    private var user: User? = null
+    private var recentPosts: List<PhotoMetadata>? = null
 
     private val connectedUserViewModel:
             ConnectedUserViewModel by viewModels(ownerProducer = { requireActivity() })
@@ -92,7 +87,7 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
         setUpUserInfo(view)
         setUpUserProfilePicture(view)
         setupFollowListener(followButton)
-        setupEditButton(editButton)
+        setupEditButton(editButton, saveButton)
         setupSaveButton(saveButton)
         setupTakePictureButton(takePictureButton)
         return view
@@ -114,13 +109,17 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
         val profilePhone: TextView = view.findViewById(R.id.fragment_profile_details_profile_phone)
         val profileEmail: TextView = view.findViewById(R.id.fragment_profile_details_profile_email)
 
-        connectedUserViewModel.currentUser.observe(viewLifecycleOwner) { cUser ->
-            val userToUse = cUser?.let { if (it.id == user?.id) it else user } ?: user
-            profileDescription.text =
-                userToUse?.description ?: getString(R.string.nav_drawer_user_description)
-            name.text = userToUse?.displayName ?: getString(R.string.nav_drawer_username)
-            profilePhone.text = userToUse?.phone
-            profileEmail.text = userToUse?.email
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                connectedUserViewModel.currentUser.collect { cUser ->
+                    val userToUse = cUser?.let { if (it.id == user?.id) it else user } ?: user
+                    profileDescription.text =
+                        userToUse?.description ?: getString(R.string.nav_drawer_user_description)
+                    name.text = userToUse?.displayName ?: getString(R.string.nav_drawer_username)
+                    profilePhone.text = userToUse?.phone
+                    profileEmail.text = userToUse?.email
+                }
+            }
         }
     }
 
@@ -130,24 +129,28 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
     private fun setUpUserProfilePicture(view: View) {
         val profileImgView: ImageView =
             view.findViewById(R.id.fragment_profile_details_profile_image)
-        connectedUserViewModel.currentUserProfilePicture.observe(viewLifecycleOwner) {
-            if (connectedUserViewModel.currentUser.value?.id == user?.id) {
-                val img = it ?: BitmapFactory.decodeResource(resources, R.drawable.blank_profile_picture)
-                profileImgView.setImageBitmap(BitmapsUtils.rescaleImage(img,
-                    PROFILE_PICTURE_DIM,
-                    PROFILE_PICTURE_DIM
-                ))
-            } else {
-                lifecycleScope.launch {
-                    val img = user?.let { user ->
-                        user.profilePictureMetadata?.let { pMetadata->
-                            FirebaseDB.getUserProfilePicture(pMetadata, user.id)
-                        }
-                    } ?: BitmapFactory.decodeResource(resources, R.drawable.blank_profile_picture)
-                    profileImgView.setImageBitmap(BitmapsUtils.rescaleImage(img,
-                        PROFILE_PICTURE_DIM,
-                        PROFILE_PICTURE_DIM
-                    ))
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                connectedUserViewModel.currentUserProfilePicture.collect {
+                    if (connectedUserViewModel.currentUser.value?.id == user?.id) {
+                        val img = it ?: BitmapFactory.decodeResource(
+                            resources,
+                            R.drawable.blank_profile_picture)
+                        profileImgView.setImageBitmap(BitmapsUtils.rescaleImage(img,
+                            PROFILE_PICTURE_DIM,
+                            PROFILE_PICTURE_DIM
+                        ))
+                    } else {
+                        val img = user?.let { user ->
+                            user.profilePictureMetadata?.let { pMetadata->
+                                FirebaseDB.getUserProfilePicture(pMetadata, user.id)
+                            }
+                        } ?: BitmapFactory.decodeResource(resources, R.drawable.blank_profile_picture)
+                        profileImgView.setImageBitmap(BitmapsUtils.rescaleImage(img,
+                            PROFILE_PICTURE_DIM,
+                            PROFILE_PICTURE_DIM
+                        ))
+                    }
                 }
             }
         }
@@ -159,12 +162,19 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
      * Setup if visible or not
      * setup its listener
      */
-    private fun setupEditButton(editButton: Button) {
+    private fun setupEditButton(editButton: Button, saveButton: Button) {
 
         // listen for currentUserChange to hide or show button accordingly
-        connectedUserViewModel.currentUser.observe(viewLifecycleOwner) {
-            if (it != user) {
-                editButton.visibility = View.GONE
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                connectedUserViewModel.currentUser.collect {
+                    if (it != user) {
+                        editButton.visibility = View.GONE
+                    } else if (saveButton.visibility == View.GONE) {
+                        // if same user and saveButton not visible, then set editButton as visible
+                        editButton.visibility = View.VISIBLE
+                    }
+                }
             }
         }
 
@@ -179,9 +189,13 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
      * Helper function to setup the save button
      */
     private fun setupSaveButton(saveButton: Button) {
-        connectedUserViewModel.currentUser.observe(viewLifecycleOwner) {
-            if (it != user) {
-                saveButton.visibility = View.GONE
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                connectedUserViewModel.currentUser.collect {
+                    if (it != user) {
+                        saveButton.visibility = View.GONE
+                    }
+                }
             }
         }
 
@@ -211,16 +225,16 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
     /**
      * Helper function to register an activity to launch the camera to take a picture
      */
-     fun registerTakePictureActivity(): ActivityResultLauncher<Void?> {
+     private fun registerTakePictureActivity(): ActivityResultLauncher<Void?> {
         return registerForActivityResult(ActivityResultContracts.TakePicturePreview(),
             testActivityRegistry ?: requireActivity().activityResultRegistry)
         { photo ->
-            val photoMetadata: PhotoMetadata =
+            val photoMetadata =
                 PhotoMetadata(takenBy = user, takenOn = ParcelableDate(Date()))
             user?.apply {
                 photo?.let {
                     // set the taken picture to the current user profile picture
-                    connectedUserViewModel.currentUserProfilePicture.value = it
+                    connectedUserViewModel.setCurrentUserProfilePicture(it, user?.id)
 
                     // store the profile picture in the database
                     lifecycleScope.launch {
@@ -312,14 +326,6 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
     }
 
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param user user to show details.
-         * @param recentPosts recent posts of the user.
-         * @return A new instance of fragment ProfileDetailsFragment.
-         */
         // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
         private const val ARG_USER = "USER"
         private const val PROFILE_PICTURE_DIM = 400
@@ -332,6 +338,15 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
             R.id.fragment_profile_details_take_picture
         )
         private const val ARG_RECENT_POSTS = "recent_posts"
+
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param user user to show details.
+         * @param photos recent posts of the user.
+         * @return A new instance of fragment ProfileDetailsFragment.
+         */
         @JvmStatic
         fun newInstance(user: User, photos: List<PhotoMetadata>) =
             ProfileDetailsFragment().apply {

--- a/app/src/main/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragment.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/fragments/ProfileDetailsFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.github.sdp_begreen.begreen.R
@@ -28,6 +29,7 @@ import com.github.sdp_begreen.begreen.models.PhotoMetadata
 import com.github.sdp_begreen.begreen.models.User
 import com.github.sdp_begreen.begreen.utils.BitmapsUtils
 import com.github.sdp_begreen.begreen.viewModels.ConnectedUserViewModel
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.util.*
 
@@ -110,8 +112,9 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
         val profileEmail: TextView = view.findViewById(R.id.fragment_profile_details_profile_email)
 
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                connectedUserViewModel.currentUser.collect { cUser ->
+            connectedUserViewModel.currentUser
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                .collect { cUser ->
                     val userToUse = cUser?.let { if (it.id == user?.id) it else user } ?: user
                     profileDescription.text =
                         userToUse?.description ?: getString(R.string.nav_drawer_user_description)
@@ -119,7 +122,6 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
                     profilePhone.text = userToUse?.phone
                     profileEmail.text = userToUse?.email
                 }
-            }
         }
     }
 
@@ -130,8 +132,9 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
         val profileImgView: ImageView =
             view.findViewById(R.id.fragment_profile_details_profile_image)
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                connectedUserViewModel.currentUserProfilePicture.collect {
+            connectedUserViewModel.currentUserProfilePicture
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                .collect {
                     if (connectedUserViewModel.currentUser.value?.id == user?.id) {
                         val img = it ?: BitmapFactory.decodeResource(
                             resources,
@@ -152,7 +155,6 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
                         ))
                     }
                 }
-            }
         }
     }
 
@@ -166,8 +168,9 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
 
         // listen for currentUserChange to hide or show button accordingly
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                connectedUserViewModel.currentUser.collect {
+            connectedUserViewModel.currentUser
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                .collect {
                     if (it != user) {
                         editButton.visibility = View.GONE
                     } else if (saveButton.visibility == View.GONE) {
@@ -175,7 +178,6 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
                         editButton.visibility = View.VISIBLE
                     }
                 }
-            }
         }
 
         editButton.setOnClickListener {
@@ -190,13 +192,13 @@ class ProfileDetailsFragment(private val testActivityRegistry: ActivityResultReg
      */
     private fun setupSaveButton(saveButton: Button) {
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                connectedUserViewModel.currentUser.collect {
+            connectedUserViewModel.currentUser
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                .collect {
                     if (it != user) {
                         saveButton.visibility = View.GONE
                     }
                 }
-            }
         }
 
         saveButton.setOnClickListener {

--- a/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
@@ -21,7 +21,7 @@ class ConnectedUserViewModel: ViewModel() {
     /**
      * Flow that dynamically retrieve authenticated user from firebase upon any modification
      */
-    private val userFromAuth = auth.getConnectedUserIds().map {
+    private val userFromAuth = auth.getFlowUserIds().map {
         it?.let { db.getUser(it) }
     }.onEach {
         // upon new connection, start by resetting the profile picture to be sure to not keep an

--- a/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
@@ -1,16 +1,86 @@
 package com.github.sdp_begreen.begreen.viewModels
 
 import android.graphics.Bitmap
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.sdp_begreen.begreen.firebase.FirebaseDB
 import com.github.sdp_begreen.begreen.models.User
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.*
 
 class ConnectedUserViewModel: ViewModel() {
-    val currentUser: MutableLiveData<User> by lazy {
-        MutableLiveData<User>()
+
+    private val mutableCurrentUser = MutableStateFlow<User?>(null)
+    private val mutableCurrentUserProfilePicture = MutableStateFlow<Bitmap?>(null)
+
+    //TODO return a flow from the future AUTH interface
+
+    /**
+     * Flow that dynamically retrieve authenticated user from firebase upon any modification
+     */
+    private val userFromAuth = callbackFlow {
+        val listener = FirebaseAuth.AuthStateListener { auth -> trySend(auth.uid) }
+        Firebase.auth.addAuthStateListener(listener)
+
+        // Unregister the listener to avoid memory leak upon flow deletion
+        awaitClose {
+            Firebase.auth.removeAuthStateListener(listener)
+        }
+    }.map {
+        it?.let { FirebaseDB.getUser(it) }
+    }.onEach {
+        // each time a new connection is done, directly fetch the user profile picture
+        // and update the currentUserProfilePicture value
+        it?.also { user ->
+            user.profilePictureMetadata?.let { photo ->
+                FirebaseDB.getUserProfilePicture(photo, user.id)
+            }?.also { photo -> mutableCurrentUserProfilePicture.value = photo }
+        }
     }
 
-    val currentUserProfilePicture: MutableLiveData<Bitmap> by lazy {
-        MutableLiveData<Bitmap>()
+    /**
+     * Merge both flows, mutableCurrentUser and userFromAuth, so that we always get
+     * the latest value either from the user updated one, or if an modification in the authenticated
+     * user arrives
+     */
+    @OptIn(FlowPreview::class)
+    val currentUser: StateFlow<User?> = flowOf(userFromAuth, mutableCurrentUser)
+        .flattenMerge()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val currentUserProfilePicture = mutableCurrentUserProfilePicture.asStateFlow()
+
+    /**
+     * Function to modify the current user
+     *
+     * Changing the current user will reset the current profile picture (i.e. set its value to null)
+     *
+     * @param user The new current user
+     */
+    fun setCurrentUser(user: User) {
+        Firebase.auth.addAuthStateListener {  }
+        mutableCurrentUser.value = user
+        mutableCurrentUserProfilePicture.value = null
+    }
+
+    /**
+     * Function to set assign a new profile picture
+     *
+     * @param bitmap The new profile picture to add to the flow
+     * @param userId The id of the user for whom we want to modify the profile picture.
+     * It has to be the id of the current user
+     * @throws IllegalArgumentException
+     */
+    fun setCurrentUserProfilePicture(bitmap: Bitmap, userId: String?) {
+
+        if (userId == null || userId != currentUser.value?.id) {
+            throw IllegalArgumentException("Trying to modify profile picture of another user")
+        }
+
+        mutableCurrentUserProfilePicture.value = bitmap
     }
 }

--- a/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
+++ b/app/src/main/java/com/github/sdp_begreen/begreen/viewModels/ConnectedUserViewModel.kt
@@ -24,6 +24,10 @@ class ConnectedUserViewModel: ViewModel() {
     private val userFromAuth = auth.getConnectedUserIds().map {
         it?.let { db.getUser(it) }
     }.onEach {
+        // upon new connection, start by resetting the profile picture to be sure to not keep an
+        // old picture, if the new authenticated person doesn't have a profile picture for example
+        mutableCurrentUserProfilePicture.value = null
+
         // each time a new connection is done, directly fetch the user profile picture
         // and update the currentUserProfilePicture value
         it?.also { user ->

--- a/app/src/main/res/drawable-v24/ic_favorite.xml
+++ b/app/src/main/res/drawable-v24/ic_favorite.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
-</vector>

--- a/app/src/main/res/drawable-v24/ic_home.xml
+++ b/app/src/main/res/drawable-v24/ic_home.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
-</vector>

--- a/app/src/main/res/drawable-v24/ic_mail.xml
+++ b/app/src/main/res/drawable-v24/ic_mail.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
-</vector>

--- a/app/src/main/res/drawable-v24/ic_menu.xml
+++ b/app/src/main/res/drawable-v24/ic_menu.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M3,18h18v-2L3,16v2zM3,13h18v-2L3,11v2zM3,6v2h18L21,6L3,6z"/>
-</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
     <string name="app_name">BeGreen</string>
     <string name="feed_fragment_text">Place where we can display a feed for this user%1$s%2$s</string>
     <string name="map_fragment_text">Fragment where we can display the map%1$s%2$s</string>
-    <string name="camera_fragment_text">Fragment where we can display the camera%1$s%2$s</string>
     <string name="advice_fragment_text">Fragment where we can display ecological advice to the user%1$s%2$s</string>
     <string name="settings_fragment_text">Fragment where we can display settings for the user%1$s%2$s</string>
     <string name="followers_fragment_text">Fragment where we can display the user\'s followers%1$s%2$s</string>
@@ -21,7 +20,6 @@
     <string name="name">PlaceholderName</string>
     <string name="user_level">PlaceholderUserLevel</string>
     <string name="profile_description">User has not a description yet…</string>
-    <string name="image_activity_recent">This is one of the recentest photo from the user</string>
     <string name="profile_user_image">This is an image for the profile of the user</string>
     <string name="add_new_post">Add new post</string>
     <string name="share_post">Share post</string>
@@ -40,7 +38,6 @@
     <string name="fragment_profile_details_take_picture">Button to take a profile picture</string>
     <string name="logout">Logout</string>
     <string name="desc_publication">This is the publication of the user</string>
-    <string name="my_title">My title</string>
     <string name="title">Title</string>
     <string name="subhead">subhead</string>
     <string name="default_description_of_the_post">Default description of the post</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
     <string name="title">Title</string>
     <string name="subhead">subhead</string>
     <string name="default_description_of_the_post">Default description of the post</string>
+    <string name="toast_logout_info">Logging Out</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '8.0.0' apply false
+    id 'com.android.library' version '8.0.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.0.0' apply false
-    id 'com.android.library' version '8.0.0' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,5 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 07 18:18:21 CET 2023
+#Sat Apr 15 12:41:08 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Mar 07 18:18:21 CET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### General description of work done

In this PR I did the following things:
- Modify the `ConnectedUserViewModel` to use `Flow` instead of `LiveData` as it offers more tools, and also added some logic to do the following:
  - Fetch the newly connected user dynamically
  - Check that when we modify a pictures, it is intended for the currently connected user

- Create a new `Auth` interface to by able to inject it using `insert-koin`
- I modified the `MainActivity` to use `insert-koin` to inject the newly created `Auth` interface
- I adapted `MainActivityTest` to work with the new injection system
- I tested the `FirebaseAuth` implementation of the `Auth` interface